### PR TITLE
apply fix for UBSan "object-size" errors

### DIFF
--- a/immer/detail/hamts/node.hpp
+++ b/immer/detail/hamts/node.hpp
@@ -99,8 +99,9 @@ struct node
 
     constexpr static std::size_t sizeof_inner_n(count_t count)
     {
-        return immer_offsetof(impl_t, d.data.inner.buffer) +
+        auto const inner_size = immer_offsetof(impl_t, d.data.inner.buffer) +
                sizeof(inner_t::buffer) * count;
+        return std::max(sizeof(node_t), inner_size);
     }
 
 #if IMMER_TAGGED_NODE


### PR DESCRIPTION
Running tests with clang-16 and the undefined behavior sanitizer (UBSan) produces errors such as the following in the immer library:
```
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior 3rdParty/immer/immer/detail/hamts/node.hpp:224:26 in
3rdParty/immer/immer/detail/hamts/node.hpp:229:12: runtime error: member access within address 0x60300009a570 with insufficient space for an object of type 'node_t' (aka 'immer::detail::hamts::node<std::pair<std::basic_string<char>, std::shared_ptr<const arangodb::consensus::Node>>, immer::map<std::basic_string<char>, std::shared_ptr<const arangodb::consensus::Node>, arangodb::consensus::Node::TransparentHash, arangodb::consensus::Node::TransparentEqual, immer::memory_policy<arangodb::consensus::Node::AccountingHeap<arangodb::immer::thread_local_free_list_heap_policy<immer::cpp_heap>>, immer::refcount_policy, immer::spinlock_policy, immer::no_transience_policy, false, true>>::hash_key, immer::map<std::basic_string<char>, std::shared_ptr<const arangodb::consensus::Node>, arangodb::consensus::Node::TransparentHash, arangodb::consensus::Node::TransparentEqual, immer::memory_policy<arangodb::consensus::Node::AccountingHeap<arangodb::immer::thread_local_free_list_heap_policy<immer::cpp_heap>>, immer::refcount_policy, immer::spinlock_policy, immer::no_transience_policy, false, true>>::equal_key, immer::memory_policy<arangodb::consensus::Node::AccountingHeap<arangodb::immer::thread_local_free_list_heap_policy<immer::cpp_heap>>, immer::refcount_policy, immer::spinlock_policy, immer::no_transience_policy, false, true>, 5>')
0x60300009a570: note: pointer points here
 00 00 00 00  01 00 00 00 be be be be  be be be be be be be be  be be be be be be be be  00 00 00 00
              ^
```
the issue was reported to the upstream version of immer via https://github.com/arximboldi/immer/issues/274.

the fix for the particular issue was written by @maierlars.